### PR TITLE
Add route to remove achievment

### DIFF
--- a/achievement_api/base.py
+++ b/achievement_api/base.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class Base(BaseModel):
+    def __repr__(self) -> str:
+        attrs = []
+        for k, v in self.__class__.model_json_schema().items():
+            attrs.append(f"{k}={v}")
+        return "{}({})".format(self.__class__.__name__, ', '.join(attrs))
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class StatusResponseModel(Base):
+    status: str
+    message: str
+    ru: str

--- a/achievement_api/routes/achievement.py
+++ b/achievement_api/routes/achievement.py
@@ -92,3 +92,15 @@ async def upload_picture(
     achievement.picture = f'static/{id}.png'
     db.session.commit()
     return achievement
+
+
+@router.delete("/{id}")
+def delete_achievement(id: int, user=Depends(UnionAuth(['achievements.achievement.create']))) -> AchievementGet:
+    """Нужны права на: `achievements.achievement.create`"""
+    achievement: Achievement | None = db.session.query(Achievement).get(id)
+    if not achievement:
+        raise HTTPException(404, f"No such achievment id={id} found")
+    logger.info(f"User id={user['id']} delete achievement {achievement.name}")
+    db.session.delete(achievement)
+    db.session.commit()
+    return achievement

--- a/achievement_api/routes/achievement.py
+++ b/achievement_api/routes/achievement.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from fastapi_sqlalchemy import db
 from pydantic import BaseModel, ConfigDict
 
+from achievement_api.base import StatusResponseModel
 from achievement_api.models import Achievement
 from achievement_api.settings import get_settings
 from achievement_api.utils.image import get_image_dimensions
@@ -94,13 +95,13 @@ async def upload_picture(
     return achievement
 
 
-@router.delete("/{id}", response_model=AchievementGet)
-def delete_achievement(id: int, user=Depends(UnionAuth(['achievements.achievement.delete']))) -> AchievementGet:
+@router.delete("/{id}", response_model=StatusResponseModel)
+def delete_achievement(id: int, user=Depends(UnionAuth(['achievements.achievement.delete']))) -> StatusResponseModel:
     """Нужны права на: `achievements.achievement.delete`"""
     achievement: Achievement | None = db.session.get(Achievement, id)
-    if not achievement:
+    if achievement is None:
         raise HTTPException(404, f"Achievement id={id} not found")
     logger.info(f"User id={user['id']} has deleted achievement {achievement.name}")
     db.session.delete(achievement)
     db.session.commit()
-    return achievement
+    return StatusResponseModel(status="Success", message=f"Achievement id={id} has been deleted", ru="Ачивка удалена")

--- a/achievement_api/routes/achievement.py
+++ b/achievement_api/routes/achievement.py
@@ -95,8 +95,8 @@ async def upload_picture(
 
 
 @router.delete("/{id}")
-def delete_achievement(id: int, user=Depends(UnionAuth(['achievements.achievement.create']))) -> AchievementGet:
-    """Нужны права на: `achievements.achievement.create`"""
+def delete_achievement(id: int, user=Depends(UnionAuth(['achievements.achievement.delete']))) -> AchievementGet:
+    """Нужны права на: `achievements.achievement.delete`"""
     achievement: Achievement | None = db.session.query(Achievement).get(id)
     if not achievement:
         raise HTTPException(404, f"No such achievment id={id} found")

--- a/achievement_api/routes/achievement.py
+++ b/achievement_api/routes/achievement.py
@@ -97,7 +97,7 @@ async def upload_picture(
 @router.delete("/{id}")
 def delete_achievement(id: int, user=Depends(UnionAuth(['achievements.achievement.delete']))) -> AchievementGet:
     """Нужны права на: `achievements.achievement.delete`"""
-    achievement: Achievement | None = db.session.query(Achievement).get(id)
+    achievement: Achievement | None = db.session.get(Achievement, id)
     if not achievement:
         raise HTTPException(404, f"No such achievment id={id} found")
     logger.info(f"User id={user['id']} delete achievement {achievement.name}")

--- a/achievement_api/routes/achievement.py
+++ b/achievement_api/routes/achievement.py
@@ -94,13 +94,13 @@ async def upload_picture(
     return achievement
 
 
-@router.delete("/{id}")
+@router.delete("/{id}", response_model=AchievementGet)
 def delete_achievement(id: int, user=Depends(UnionAuth(['achievements.achievement.delete']))) -> AchievementGet:
     """Нужны права на: `achievements.achievement.delete`"""
     achievement: Achievement | None = db.session.get(Achievement, id)
     if not achievement:
-        raise HTTPException(404, f"No such achievment id={id} found")
-    logger.info(f"User id={user['id']} delete achievement {achievement.name}")
+        raise HTTPException(404, f"Achievement id={id} not found")
+    logger.info(f"User id={user['id']} has deleted achievement {achievement.name}")
     db.session.delete(achievement)
     db.session.commit()
     return achievement

--- a/achievement_api/routes/achievement.py
+++ b/achievement_api/routes/achievement.py
@@ -100,8 +100,8 @@ def delete_achievement(id: int, user=Depends(UnionAuth(['achievements.achievemen
     """Нужны права на: `achievements.achievement.delete`"""
     achievement: Achievement | None = db.session.get(Achievement, id)
     if achievement is None:
-        raise HTTPException(404, f"Achievement id={id} not found")
+        raise HTTPException(404, f"Achievement {id=} not found")
     logger.info(f"User id={user['id']} has deleted achievement {achievement.name}")
     db.session.delete(achievement)
     db.session.commit()
-    return StatusResponseModel(status="Success", message=f"Achievement id={id} has been deleted", ru="Ачивка удалена")
+    return StatusResponseModel(status="Success", message=f"Achievement {id=} has been deleted", ru="Ачивка удалена")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,24 +23,9 @@ def dbsession():
 
 @pytest.fixture
 def achievement(dbsession):
-    """
-    Вызов фабрики создает ачивку
-    ```
-    def test(achievement):
-        achievement1 = achievement()
-        achievement2 = achievement()
-    ```
-    """
-    achievements = []
-
-    def _achievement():
-        nonlocal achievements
-        name = "Test achievement"
-        owner_id = 1
-        __achievement = Achievement(name=name, description="", owner_user_id=owner_id)
-        dbsession.add(__achievement)
-        dbsession.commit()
-        achievements.append(__achievement)
-        return __achievement
-
-    yield _achievement
+    name = "Test achievement"
+    owner_id = 1
+    achievement = Achievement(name=name, description="", owner_user_id=owner_id)
+    dbsession.add(achievement)
+    dbsession.commit()
+    yield achievement

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,19 +14,15 @@ def client():
 
 
 @pytest.fixture(scope='session')
-def dbsessionGen():
-
-    def _dbsession():
-        settings = get_settings()
-        engine = create_engine(str(settings.DB_DSN))
-        TestingSessionLocal = sessionmaker(bind=engine)
-        return TestingSessionLocal()
-
-    yield _dbsession
+def dbsession():
+    settings = get_settings()
+    engine = create_engine(str(settings.DB_DSN))
+    TestingSessionLocal = sessionmaker(bind=engine)
+    yield TestingSessionLocal()
 
 
 @pytest.fixture
-def achievement(dbsessionGen):
+def achievement(dbsession):
     """
     Вызов фабрики создает ачивку
     ```
@@ -36,7 +32,6 @@ def achievement(dbsessionGen):
     ```
     """
     achievements = []
-    dbsession = dbsessionGen()
 
     def _achievement():
         nonlocal achievements

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,51 @@
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
+from achievement_api.models.achievement import Achievement
 from achievement_api.routes.base import app
+from achievement_api.settings import get_settings
 
 
 @pytest.fixture
 def client():
     yield TestClient(app)
+
+
+@pytest.fixture(scope='session')
+def dbsessionGen():
+
+    def _dbsession():
+        settings = get_settings()
+        engine = create_engine(str(settings.DB_DSN))
+        TestingSessionLocal = sessionmaker(bind=engine)
+        return TestingSessionLocal()
+
+    yield _dbsession
+
+
+@pytest.fixture
+def achievement(dbsessionGen):
+    """
+    Вызов фабрики создает ачивку
+    ```
+    def test(achievement):
+        achievement1 = achievement()
+        achievement2 = achievement()
+    ```
+    """
+    achievements = []
+    dbsession = dbsessionGen()
+
+    def _achievement():
+        nonlocal achievements
+        name = "Test achievement"
+        owner_id = 1
+        __achievement = Achievement(name=name, description="", owner_user_id=owner_id)
+        dbsession.add(__achievement)
+        dbsession.commit()
+        achievements.append(__achievement)
+        return __achievement
+
+    yield _achievement

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from achievement_api.models.achievement import Achievement
 from achievement_api.routes.base import app
 from achievement_api.settings import get_settings
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,10 +22,6 @@ def dbsession():
 
 
 @pytest.fixture
-def achievement(dbsession):
-    name = "Test achievement"
-    owner_id = 1
-    achievement = Achievement(name=name, description="", owner_user_id=owner_id)
-    dbsession.add(achievement)
-    dbsession.commit()
-    yield achievement
+def achievement_id(client):
+    post_response = client.post("/achievement", json={"name": "test name", "description": "test description"})
+    yield post_response.json()["id"]

--- a/tests/test_routes/test_achievement.py
+++ b/tests/test_routes/test_achievement.py
@@ -4,11 +4,10 @@ from achievement_api.models.achievement import Achievement
 
 
 @pytest.mark.authenticated("achievements.achievement.create", "achievements.achievement.delete")
-def test_delete_existed(client, dbsession):
-    post_response = client.post("/achievement", json={"name": "test name", "description": "test description"})
-    delete_response = client.delete(f"/achievement/{post_response.json()['id']}")
+def test_delete_existed(client, dbsession, achievement_id):
+    delete_response = client.delete(f"/achievement/{achievement_id}")
     assert delete_response.status_code == 200
-    query = dbsession.get(Achievement, post_response.json()["id"])
+    query = dbsession.get(Achievement, achievement_id)
     assert query is None
 
 

--- a/tests/test_routes/test_achievement.py
+++ b/tests/test_routes/test_achievement.py
@@ -1,0 +1,20 @@
+import pytest
+
+from achievement_api.models.achievement import Achievement
+
+
+@pytest.mark.authenticated("achievements.achievement.delete")
+def test_delete_existed(client, dbsessionGen, achievement):
+    _achievement = achievement()
+    response = client.delete(f"/achievement/{_achievement.id}")
+    assert response.status_code == 200
+    dbsession = dbsessionGen()
+    query = dbsession.query(Achievement).get(_achievement.id)
+    assert query is None
+
+
+@pytest.mark.authenticated("achievements.achievement.delete")
+def test_delete_unexisted(client):
+    unexisted_id = -1
+    response = client.delete(f"/achievement/{unexisted_id}")
+    assert response.status_code == 404

--- a/tests/test_routes/test_achievement.py
+++ b/tests/test_routes/test_achievement.py
@@ -3,12 +3,12 @@ import pytest
 from achievement_api.models.achievement import Achievement
 
 
-@pytest.mark.authenticated("achievements.achievement.delete")
-def test_delete_existed(client, dbsession, achievement):
-    _achievement = achievement()
-    response = client.delete(f"/achievement/{_achievement.id}")
-    assert response.status_code == 200
-    query = dbsession.query(Achievement).get(_achievement.id)
+@pytest.mark.authenticated("achievements.achievement.create", "achievements.achievement.delete")
+def test_delete_existed(client, dbsession):
+    post_response = client.post("/achievement", json={"name": "test name", "description": "test description"})
+    delete_response = client.delete(f"/achievement/{post_response.json()['id']}")
+    assert delete_response.status_code == 200
+    query = dbsession.get(Achievement, post_response.json()["id"])
     assert query is None
 
 

--- a/tests/test_routes/test_achievement.py
+++ b/tests/test_routes/test_achievement.py
@@ -4,11 +4,10 @@ from achievement_api.models.achievement import Achievement
 
 
 @pytest.mark.authenticated("achievements.achievement.delete")
-def test_delete_existed(client, dbsessionGen, achievement):
+def test_delete_existed(client, dbsession, achievement):
     _achievement = achievement()
     response = client.delete(f"/achievement/{_achievement.id}")
     assert response.status_code == 200
-    dbsession = dbsessionGen()
     query = dbsession.query(Achievement).get(_achievement.id)
     assert query is None
 


### PR DESCRIPTION
## Изменения
Добавил ручку delete для achievement с тестами

## Детали реализации
Добавил ручку delete с необходимым скоупом achievements.achievement.delete для удаления ачивок по id.
Работает следующим образом:
1. Запрашивает ачивку по id
2. Если такая ачивка существует
2.1. Ачивка удаляется из бд
2.2. Удалённая ачивка возвращается, как json
3. Если такая ачивка не существует
3.1. Поднимается ошибка 404

Написал тесты для проверки удаления существующих и не существующих ачивок.

## Check-List
<!-- После сохранения у следующих полей появятся галочки, которые нужно проставить мышкой -->
- [x] Вы проверили свой код перед отправкой запроса?
- [x] Вы написали тесты к реализованным функциям?
- [x] Вы не забыли применить форматирование `black` и `isort` для _Back-End_ или `Prettier` для _Front-End_?
