### PR TITLE
Fix get achievement route

### DIFF
--- a/achievement_api/routes/achievement.py
+++ b/achievement_api/routes/achievement.py
@@ -44,7 +44,7 @@ def get_all_achievements() -> list[AchievementGet]:
 
 @router.get("/{id}")
 def get_achievement(id: int) -> AchievementGet:
-    achievement = db.session.query(Achievement).filter(Achievement.id == id)
+    achievement = db.session.get(Achievement, id)
     if achievement is None:
         raise HTTPException(404, "The achievement was not found")
     return achievement

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from achievement_api.models.achievement import Achievement
 from achievement_api.routes.base import app
 from achievement_api.settings import get_settings
 
@@ -21,6 +22,9 @@ def dbsession():
 
 
 @pytest.fixture
-def achievement_id(client):
+def achievement_id(client, dbsession):
     post_response = client.post("/achievement", json={"name": "test name", "description": "test description"})
-    yield post_response.json()["id"]
+    id = post_response.json()["id"]
+    yield id
+    if dbsession.get(Achievement, id):
+        client.delete(f"/achievement/{id}")

--- a/tests/test_routes/test_achievement.py
+++ b/tests/test_routes/test_achievement.py
@@ -16,3 +16,37 @@ def test_delete_unexisted(client):
     unexisted_id = -1
     response = client.delete(f"/achievement/{unexisted_id}")
     assert response.status_code == 404
+
+
+@pytest.mark.authenticated("achievements.achievement.create", "achievements.achievement.delete")
+def test_get_existed(client, achievement_id):
+    response = client.get(f"/achievement/{achievement_id}")
+    assert response.status_code == 200
+    assert response.json()["id"] == achievement_id
+
+
+def test_get_unexisted(client):
+    unexisted_id = -1
+    response = client.get(f"/achievement/{unexisted_id}")
+    assert response.status_code == 404
+
+
+@pytest.mark.authenticated(
+    "achievements.achievement.create", "achievements.achievement.edit", "achievements.achievement.delete"
+)
+def test_edit_existed(client, achievement_id):
+    body = {"name": "new name", "description": "new description"}
+    response = client.patch(f"/achievement/{achievement_id}", json=body)
+    assert response.status_code == 200
+    response = client.get(f"/achievement/{achievement_id}")
+    assert response.json()["id"] == achievement_id
+    assert response.json()["name"] == body["name"]
+    assert response.json()["description"] == body["description"]
+
+
+@pytest.mark.authenticated("achievements.achievement.edit")
+def test_edit_unexisted(client):
+    body = {"name": "new name", "description": "new description"}
+    unexisted_id = -1
+    response = client.patch(f"/achievement/{unexisted_id}", json=body)
+    assert response.status_code == 404


### PR DESCRIPTION
## Изменения
Починил получение ачивки по id 

## Детали реализации
Получение ачивки по id теперь возвращает ачивку, если ачивка с таким id существует

Также были добавлены тесты для проверки нескольких ручек

## Check-List
<!-- После сохранения у следующих полей появятся галочки, которые нужно проставить мышкой -->
- [ ] Вы проверили свой код перед отправкой запроса?
- [ ] Вы написали тесты к реализованным функциям?
- [ ] Вы не забыли применить форматирование `black` и `isort` для _Back-End_ или `Prettier` для _Front-End_?
